### PR TITLE
Fix getting camera FOV

### DIFF
--- a/ofxARCoreLib/src/main/java/cc/ofxarcorelib/ofxARCoreLib.java
+++ b/ofxARCoreLib/src/main/java/cc/ofxarcorelib/ofxARCoreLib.java
@@ -506,12 +506,16 @@ public class ofxARCoreLib extends OFAndroidObject {
                 CameraCharacteristics characteristics = cManager.getCameraCharacteristics(cameraId);
                 int cOrientation = characteristics.get(CameraCharacteristics.LENS_FACING);
                 if (cOrientation == CameraCharacteristics.LENS_FACING_BACK) {
+
                     float[] maxFocus = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS);
                     SizeF size = characteristics.get(CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE);
+
                     float w = size.getWidth();
                     float h = size.getHeight();
-                    horizontalAngle = -w/(maxFocus[0]*2);
-                    verticalAngle = (float) (2*Math.atan(h/(maxFocus[0]*2)));
+
+                    horizontalAngle = (float) Math.toDegrees(2 * Math.atan(w / (maxFocus[0] * 2.0)));
+                    verticalAngle = (float) Math.toDegrees(2 * Math.atan(h / (maxFocus[0] * 2.0)));
+
                     return;
                 }
             }


### PR DESCRIPTION
On my Pixel 3a ```arcore.getCameraFOV()``` would report ```-0.635676```.
I've updated the code (as per [this example on StackOverflow](https://stackoverflow.com/questions/52828668/how-to-calculate-field-of-view-in-arcore)) and now the returned value is ```64.8863``` which seems more reasonable.